### PR TITLE
Add undefined check for ll.lovelace and ll.lovelace.config

### DIFF
--- a/kiosk-mode.js
+++ b/kiosk-mode.js
@@ -10,7 +10,9 @@ function getConfig() {
     llAttempts++
     setTimeout(() => getConfig(), 50)
   }
-  return ll && ll.lovelace.config.kiosk_mode ? ll.lovelace.config.kiosk_mode : {};
+  return ll && ll.lovelace && ll.lovelace.config && ll.lovelace.config.kiosk_mode
+    ? ll.lovelace.config.kiosk_mode
+    : {};
 }
 
 // Return true if any keyword is found in location.


### PR DESCRIPTION
An attempt to resolve https://github.com/maykar/kiosk-mode/issues/39 and https://github.com/maykar/kiosk-mode/issues/37. It seems like there are cases when ll.lovelace is undefined which leads to uncaught TypeError:
kiosk-mode.js:18:15 Uncaught TypeError: Cannot read property 'config' of undefined

It seems thought that code is expecting similar situations to happen already and adding additional conditions is a safe fix.